### PR TITLE
feat: add chain

### DIFF
--- a/packages/blueflag-rxjs/README.md
+++ b/packages/blueflag-rxjs/README.md
@@ -2,12 +2,39 @@
 
 Rxjs algorithms.
 
+- [chain](#chain)
 - [zipDiff](#zipDiff)
 - [operators/bufferDistinct](#operators/bufferDistinct)
 - [operators/complete](#operators/complete)
 - [dynamodb/batchGet](#dynamodb/batchGet)
 - [dynamodb/batchWrite](#dynamodb/batchWrite)
 - [dynamodb/queryAll](#dynamodb/queryAll)
+
+## chain
+
+Takes multiple observables and concats them, but emits all items.
+
+```js
+import {chain} from 'blueflag-rxjs';
+
+chain(
+    obsA: Observable,
+    obsB: Observable,
+    ...
+): Observable
+```
+
+```js
+chain(obsA, obsB)
+
+// obsA adds "1"
+// obsA adds "2"
+// obsB adds "3"
+// obsB adds "4"
+
+// output: "1", "2", "3", "4"
+
+```
 
 ## zipDiff
 

--- a/packages/blueflag-rxjs/src/__tests__/chain-test.js
+++ b/packages/blueflag-rxjs/src/__tests__/chain-test.js
@@ -1,0 +1,55 @@
+// @flow
+import {TestScheduler} from 'rxjs/testing';
+import chain from '../chain';
+
+describe('chain', () => {
+
+    it('chain should chain observables togther (concatAll() style) while emitting all items from all observables', () => {
+
+        const testScheduler = new TestScheduler((actual, expected) => {
+            expect(actual).toEqual(expected);
+        });
+
+        testScheduler.run(helpers => {
+            const {cold, expectObservable, expectSubscriptions} = helpers;
+
+            const a =   cold('-a-b-c-|');
+            const aSubs =    '^------!';
+            const b =          cold('-d-e-f-|');
+            const bSubs =    '-------^------!';
+            const c =                 cold('-g-h-i-|');
+            const cSubs =    '--------------^------!';
+            const expected = '-a-b-c--d-e-f--g-h-i-|';
+
+            expectObservable(
+                chain(a, b, c)
+            ).toBe(expected);
+
+            expectSubscriptions(a.subscriptions).toBe(aSubs);
+            expectSubscriptions(b.subscriptions).toBe(bSubs);
+            expectSubscriptions(c.subscriptions).toBe(cSubs);
+        });
+    });
+
+    it('chain should be able to unsubscribe early', () => {
+
+        const testScheduler = new TestScheduler((actual, expected) => {
+            expect(actual).toEqual(expected);
+        });
+
+        testScheduler.run(helpers => {
+            const {cold, expectObservable, expectSubscriptions} = helpers;
+
+            const a =   cold('--a-|');
+            const subs =     '^---!';
+            const expected = '--a-|';
+
+            expectObservable(
+                chain(a)
+            ).toBe(expected);
+
+            expectSubscriptions(a.subscriptions).toBe(subs);
+        });
+    });
+
+});

--- a/packages/blueflag-rxjs/src/__tests__/index-test.js
+++ b/packages/blueflag-rxjs/src/__tests__/index-test.js
@@ -1,7 +1,10 @@
 // @flow
+import {chain} from '../index';
+import chainOriginal from '../chain';
 import {zipDiff} from '../index';
 import zipDiffOriginal from '../zipDiff';
 
 test('index should export everything', () => {
+    expect(chain).toBe(chainOriginal);
     expect(zipDiff).toBe(zipDiffOriginal);
 });

--- a/packages/blueflag-rxjs/src/chain.js
+++ b/packages/blueflag-rxjs/src/chain.js
@@ -1,0 +1,44 @@
+// @flow
+
+import {Observable, Subscription} from 'rxjs';
+
+export type ObservableGenerator<T> = Observable<T> | ((v: T) => Observable<T>);
+
+// from https://stackblitz.com/edit/rxjs-ruj1m3
+// and discussed here https://github.com/ReactiveX/rxjs/issues/4711
+
+export default function chain<T>(seed: Observable<T>, ...obsGenerators: Array<ObservableGenerator<T>>) {
+    return new Observable<T>(masterSubscriber => {
+        let lastValueFromPrev: T;
+        let childSubscription: Subscription;
+
+        const switchTo = (obs: Observable<T>) => {
+            childSubscription = obs.subscribe({
+                next: v => {
+                    lastValueFromPrev = v;
+                    masterSubscriber.next(v);
+                },
+                error: masterSubscriber.error,
+                complete: () => {
+                    /* istanbul ignore next */
+                    if(childSubscription) {
+                        childSubscription.unsubscribe();
+                    }
+                    const next = obsGenerators.shift();
+                    if(!next) {
+                        masterSubscriber.complete();
+                    } else {
+                        /* istanbul ignore next */
+                        switchTo(typeof next === 'function' ? next(lastValueFromPrev) : next);
+                    }
+                }
+            });
+        };
+
+        switchTo(seed);
+
+        return () => {
+            childSubscription.unsubscribe();
+        };
+    });
+}

--- a/packages/blueflag-rxjs/src/index.js
+++ b/packages/blueflag-rxjs/src/index.js
@@ -1,2 +1,3 @@
 // @flow
+export {default as chain} from './chain';
 export {default as zipDiff} from './zipDiff';


### PR DESCRIPTION
Code from https://stackblitz.com/edit/rxjs-ruj1m3
Discussion saying how rxjs devs would rather this function live in userland https://github.com/ReactiveX/rxjs/issues/4711

## chain

 Takes multiple observables and concats them, but emits all items as they occur. i.e. obsA items will emit before obsB is done.

 ```js
import {chain} from 'blueflag-rxjs';
 chain(
    obsA: Observable,
    obsB: Observable, // should be () => Observable
    ...
): Observable
```

 ```js
chain(obsA, obsB)
 // obsA adds "1"
// obsA adds "2"
// obsB adds "3"
// obsB adds "4"
 // output: "1", "2", "3", "4"
 ```
