### PR TITLE
Include missing files from package

### DIFF
--- a/packages/92green-aws-rxjs/dynamodb/index.js
+++ b/packages/92green-aws-rxjs/dynamodb/index.js
@@ -1,2 +1,2 @@
 // required to make 92green-rxjs/dynamodb imports work
-module.exports = require('../lib/dynamodb/index.js');
+module.exports = require('../dist/dynamodb/index.js');

--- a/packages/92green-aws-rxjs/eventbus/index.js
+++ b/packages/92green-aws-rxjs/eventbus/index.js
@@ -1,1 +1,1 @@
-module.exports = require('../lib/eventbus/index.js');
+module.exports = require('../dist/eventbus/index.js');

--- a/packages/92green-aws-rxjs/operators/index.js
+++ b/packages/92green-aws-rxjs/operators/index.js
@@ -1,2 +1,0 @@
-// required to make 92green-rxjs/operator imports work
-module.exports = require('../lib/operators/index.js');

--- a/packages/92green-aws-rxjs/package.json
+++ b/packages/92green-aws-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@92green/92green-aws-rxjs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Rxjs algorithms for use with AWS SDK v3",
   "license": "MIT",
   "author": "Blueflag",
@@ -12,8 +12,8 @@
     "url": "https://github.com/92green/92green-stream/issues"
   },
   "files": [
-    "lib",
-    "operators",
+    "dist",
+    "eventbus",
     "dynamodb"
   ],
   "main": "lib/index.js",


### PR DESCRIPTION
* This fixes the broken package @92green/92green-aws-rxjs:0.11.0 as it is missing the required files (I'm not sure how previous published versions worked successfully)